### PR TITLE
Upgrade rxdart from 0.20 to 0.23

### DIFF
--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -34,11 +34,11 @@ Reducer<State> combineReducers<State>(List<Reducer<State>> reducers) {
 /// Epics cannot prevent actions from being handled by the reducers.
 ///
 /// If an incoming action is passed through, an infinite loop is created.
-typedef Epic<State> = Stream<Action> Function(Stream<Action> actions, ValueObservable<State> state);
+typedef Epic<State> = Stream<Action> Function(Stream<Action> actions, ValueStream<State> state);
 
 /// Combines a list of [Epic]s into one.
 Epic<State> combineEpics<State>(List<Epic<State>> epics) {
-  return (Stream<Action> actions, ValueObservable<State> state) {
+  return (Stream<Action> actions, ValueStream<State> state) {
     return MergeStream<Action>(epics.map((Epic<State> epic) => epic(actions, state)));
   };
 }
@@ -51,7 +51,7 @@ Epic<State> combineEpics<State>(List<Epic<State>> epics) {
 /// Listen to the [state] stream to get the current state and receive updates.
 class Store<State> {
   Store(this._reducer, {State initialState, Epic<State> epic, bool sync = false})
-      : _changeSubject = BehaviorSubject<State>(seedValue: initialState, sync: sync),
+      : _changeSubject = BehaviorSubject<State>.seeded(initialState, sync: sync),
         _dispatchSubject = PublishSubject<Action>(sync: sync) {
     if (epic != null) {
       final actions = epic(_dispatchSubject.stream, state);
@@ -65,7 +65,7 @@ class Store<State> {
   final BehaviorSubject<State> _changeSubject;
   final PublishSubject<Action> _dispatchSubject;
 
-  ValueObservable<State> get state => _changeSubject.stream;
+  ValueStream<State> get state => _changeSubject.stream;
 
   StreamSink<Action> get dispatcher => _dispatchSubject.sink;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.1.0 <3.0.0"
 
 dependencies:
-  rxdart: ^0.20.0
+  rxdart: ">=0.23.0 <0.24.0"
 
 dev_dependencies:
   pedantic: ^1.9.0

--- a/test/store_test.dart
+++ b/test/store_test.dart
@@ -65,7 +65,7 @@ void main() {
 
     group('with epics', () {
       test('passes the action stream to the epic', () {
-        Stream<Action> epic(Stream<Action> actions, ValueObservable<int> state) {
+        Stream<Action> epic(Stream<Action> actions, ValueStream<int> state) {
           expect(actions, emitsInOrder(<AddInt>[const AddInt(42), const AddInt(1337)]));
 
           return const Stream<Action>.empty();
@@ -77,11 +77,8 @@ void main() {
       });
 
       test('dispatches the emitted actions', () async {
-        Stream<Action> epic(Stream<Action> actions, ValueObservable<int> state) {
-          return Observable<Action>(actions)
-              .ofType(const TypeToken<AddInt>())
-              .map((AddInt action) => const MultiplyInt(2));
-        }
+        Stream<Action> epic(Stream<Action> actions, ValueStream<int> state) =>
+            actions.whereType<AddInt>().map((AddInt action) => const MultiplyInt(2));
 
         final store = Store<int>(intReducer, initialState: 0, epic: epic);
 
@@ -97,7 +94,7 @@ void main() {
       });
 
       test('throws if null is emitted', () async {
-        Stream<Action> epic(Stream<Action> actions, ValueObservable<int> state) {
+        Stream<Action> epic(Stream<Action> actions, ValueStream<int> state) {
           return null;
         }
 
@@ -105,13 +102,13 @@ void main() {
       });
 
       test('passes the action stream to combined epics', () {
-        Stream<Action> epicOne(Stream<Action> actions, ValueObservable<int> state) {
+        Stream<Action> epicOne(Stream<Action> actions, ValueStream<int> state) {
           expect(actions, emitsInOrder(<AddInt>[const AddInt(42), const AddInt(1337)]));
 
           return const Stream<Action>.empty();
         }
 
-        Stream<Action> epicTwo(Stream<Action> actions, ValueObservable<int> state) {
+        Stream<Action> epicTwo(Stream<Action> actions, ValueStream<int> state) {
           expect(actions, emitsInOrder(<AddInt>[const AddInt(42), const AddInt(1337)]));
 
           return const Stream<Action>.empty();


### PR DESCRIPTION
The previously defined version (^0.20.0) came from the codebase from which `rxstore` is extracted. Now a version range is defined which is more suitable for a library.
