### PR TITLE
Release rxstore 0.3.0

### DIFF
--- a/packages/rxstore/CHANGELOG.md
+++ b/packages/rxstore/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0
+- Ensure that the reducer runs before the epic
+
 ## 0.2.1
 - Update API docs
 - Update the README

--- a/packages/rxstore/pubspec.yaml
+++ b/packages/rxstore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rxstore
 description: Stream-based Redux implementation with support for side-effects.
-version: 0.2.1
+version: 0.3.0
 homepage: https://github.com/johanflint/rxstore.dart
 
 environment:


### PR DESCRIPTION
- Ensure that the reducer runs before the epic
