### PR TITLE
Create state stream builder

### DIFF
--- a/packages/flutter_rxstore/lib/flutter_rxstore.dart
+++ b/packages/flutter_rxstore/lib/flutter_rxstore.dart
@@ -1,3 +1,4 @@
 library flutter_rxstore;
 
+export 'src/state_stream_builder.dart';
 export 'src/store_provider.dart';

--- a/packages/flutter_rxstore/lib/src/state_stream_builder.dart
+++ b/packages/flutter_rxstore/lib/src/state_stream_builder.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_rxstore/flutter_rxstore.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:rxstore/rxstore.dart';
+
+typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, T state);
+
+/// Widget that builds itself based on the latest state from the [Store].
+///
+/// The initial data is always set as the state stream from the store is never
+/// empty.
+///
+/// Important: provide the full generic type when using the widget otherwise
+/// Flutter will not be able to find the provider.
+class StateStreamBuilder<State> extends StatelessWidget {
+  const StateStreamBuilder({
+    Key? key,
+    required this.builder,
+  }) : super(key: key);
+
+  /// The build strategy currently used by this builder.
+  ///
+  /// This builder must only return a widget and should not have any side
+  /// effects as it may be called multiple times.
+  final AsyncWidgetBuilder<State> builder;
+
+  @override
+  Widget build(BuildContext context) {
+    final Store<State> store = StoreProvider.of<State>(context);
+
+    return StreamBuilder<State>(
+      stream: store.state.map((event) => event),
+      initialData: store.state.value,
+      builder: (BuildContext context, AsyncSnapshot<State> snapshot) {
+        return builder(context, snapshot.requireData);
+      },
+    );
+  }
+}

--- a/packages/flutter_rxstore/pubspec.yaml
+++ b/packages/flutter_rxstore/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxstore: ^0.2.1
+  rxstore: ">=0.3.0 <1.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_rxstore/test/state_stream_builder_test.dart
+++ b/packages/flutter_rxstore/test/state_stream_builder_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/widgets.dart' hide Action;
+import 'package:flutter_rxstore/flutter_rxstore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:rxstore/rxstore.dart';
+
+void main() {
+  group('State stream builder', () {
+    testWidgets('passes the initial state to the build function', (WidgetTester tester) async {
+      final Store<int> store = Store<int>(intReducer, initialState: 42);
+
+      int receivedState = 0;
+
+      final StoreProvider<int> widget = StoreProvider<int>(
+        store: store,
+        child: StateStreamBuilder<int>(
+          builder: (context, state) {
+            receivedState = state;
+
+            return const SizedBox();
+          },
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+
+      expect(receivedState, 42);
+    });
+
+    testWidgets('passes the updated state to the build function', (WidgetTester tester) async {
+      final Store<int> store = Store<int>(intReducer, initialState: 42)..dispatch(AddInt(2));
+
+      int receivedState = 0;
+
+      final StoreProvider<int> widget = StoreProvider<int>(
+        store: store,
+        child: StateStreamBuilder<int>(
+          builder: (context, state) {
+            receivedState = state;
+
+            return const SizedBox();
+          },
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+
+      expect(receivedState, 44);
+    });
+  });
+}
+
+class AddInt implements Action {
+  const AddInt(this.payload);
+
+  final int payload;
+
+  @override
+  String toString() => 'AddInt{payload: $payload}';
+}
+
+int intReducer(int state, Action action) {
+  if (action is AddInt) {
+    return state + action.payload;
+  }
+
+  return state;
+}


### PR DESCRIPTION
A convenience widget that looks up the store and uses a stream builder with initial data set to build its children.