### PR TITLE
Release rxstore 0.4.0

### DIFF
--- a/packages/rxstore/CHANGELOG.md
+++ b/packages/rxstore/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 0.4.0
+- Ensure that the reducer runs before the epic 
+
 ## 0.3.0
-- Ensure that the reducer runs before the epic
+- Because of a failed release, this version is identical to 0.2.1
 
 ## 0.2.1
 - Update API docs

--- a/packages/rxstore/pubspec.yaml
+++ b/packages/rxstore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rxstore
 description: Stream-based Redux implementation with support for side-effects.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/johanflint/rxstore.dart
 
 environment:


### PR DESCRIPTION
- Ensure that the reducer runs before the epic 
