### PR TITLE
Add dispatch to the builder function

### DIFF
--- a/packages/flutter_rxstore/CHANGELOG.md
+++ b/packages/flutter_rxstore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Pass a dispatch function to the StateStreamBuilder's builder
+
 ## 0.2.0
 
 - Introduce StateStreamBuilder

--- a/packages/flutter_rxstore/lib/src/state_stream_builder.dart
+++ b/packages/flutter_rxstore/lib/src/state_stream_builder.dart
@@ -1,9 +1,17 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' hide Action;
 import 'package:flutter_rxstore/flutter_rxstore.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:rxstore/rxstore.dart';
 
-typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, T state);
+/// Function that dispatches the action by passing it to the reducer and,
+/// optionally, the epic.
+typedef Dispatch = void Function(Action action);
+
+/// Called whenever the state in the [Store] changes.
+///
+/// This builder must only return a widget and should not have any side
+/// effects as it may be called multiple times.
+typedef AsyncWidgetBuilder<T> = Widget Function(BuildContext context, T state, Dispatch dispatch);
 
 /// Widget that builds itself based on the latest state from the [Store].
 ///
@@ -32,7 +40,7 @@ class StateStreamBuilder<State> extends StatelessWidget {
       stream: store.state.map((event) => event),
       initialData: store.state.value,
       builder: (BuildContext context, AsyncSnapshot<State> snapshot) {
-        return builder(context, snapshot.requireData);
+        return builder(context, snapshot.requireData, store.dispatch);
       },
     );
   }

--- a/packages/flutter_rxstore/pubspec.yaml
+++ b/packages/flutter_rxstore/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_rxstore
 description: Contains a Flutter widget to easily obtain a reference to an rxstore
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/johanflint/rxstore.dart
 
 environment:

--- a/packages/flutter_rxstore/test/state_stream_builder_test.dart
+++ b/packages/flutter_rxstore/test/state_stream_builder_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart' hide Action;
 import 'package:flutter_rxstore/flutter_rxstore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:rxstore/rxstore.dart';
 
 void main() {
@@ -13,7 +14,7 @@ void main() {
       final StoreProvider<int> widget = StoreProvider<int>(
         store: store,
         child: StateStreamBuilder<int>(
-          builder: (context, state) {
+          builder: (context, state, dispatch) {
             receivedState = state;
 
             return const SizedBox();
@@ -34,7 +35,7 @@ void main() {
       final StoreProvider<int> widget = StoreProvider<int>(
         store: store,
         child: StateStreamBuilder<int>(
-          builder: (context, state) {
+          builder: (context, state, dispatch) {
             receivedState = state;
 
             return const SizedBox();
@@ -45,6 +46,25 @@ void main() {
       await tester.pumpWidget(widget);
 
       expect(receivedState, 44);
+    });
+
+    testWidgets('passes dispatch to the build function', (WidgetTester tester) async {
+      final Store<int> store = Store<int>(intReducer, initialState: 42);
+
+      final StoreProvider<int> widget = StoreProvider<int>(
+        store: store,
+        child: StateStreamBuilder<int>(
+          builder: (context, state, dispatch) {
+            dispatch(AddInt(2));
+
+            return const SizedBox();
+          },
+        ),
+      );
+
+      await tester.pumpWidget(widget);
+
+      expect(store.state.value, 44);
     });
   });
 }


### PR DESCRIPTION
This removes the need to use the StoreProvider to look up a store in order to dispatch actions.